### PR TITLE
Improve domain validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,9 @@ extract-msg>=0.41.0
 # Enables extraction of attachments from TNEF containers
 tnefparse>=1.3.0
 
+# Optional: Validate domains using TLD lists
+tldextract>=3.4.0
+
 # Optional: Improved charset detection
 # Provides better text encoding detection for email content
 chardet>=5.0.0


### PR DESCRIPTION
## Summary
- check TLDs using tldextract when extracting domains
- require valid TLD in URL and domain detection
- add tldextract as optional dependency

## Testing
- `python -m py_compile parse_email/email_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_685d6e8362748324828037ffd0858d00