### PR TITLE
Add URL processing with shortener expansion

### DIFF
--- a/parse_email/__init__.py
+++ b/parse_email/__init__.py
@@ -1,2 +1,11 @@
 from .email_parser import EmailParser
 from .debug_utils import debug_email_structure
+from .url import UrlProcessor, UrlValidator, UrlDecoder
+
+__all__ = [
+    "EmailParser",
+    "debug_email_structure",
+    "UrlProcessor",
+    "UrlValidator",
+    "UrlDecoder",
+]

--- a/parse_email/cli.py
+++ b/parse_email/cli.py
@@ -79,7 +79,8 @@ def main():
                 
                 # Show sample artifacts if found
                 if artifacts['urls'][:3]:
-                    print(f"    Sample URLs: {', '.join(artifacts['urls'][:3])}")
+                    sample_urls = [u['original_url'] for u in artifacts['urls'][:3] if isinstance(u, dict)]
+                    print(f"    Sample URLs: {', '.join(sample_urls)}")
                 if artifacts['ip_addresses'][:3]:
                     print(f"    Sample IPs: {', '.join(artifacts['ip_addresses'][:3])}")
                 if artifacts['domains'][:3]:

--- a/parse_email/email_parser.py
+++ b/parse_email/email_parser.py
@@ -31,6 +31,9 @@ from email import policy
 from email.parser import BytesParser
 from email.message import EmailMessage
 
+# URL processing utilities
+from .url.processor import UrlProcessor
+
 class EmailParser:
     """Parser using standard library email package with artifact extraction"""
     
@@ -915,13 +918,17 @@ class EmailParser:
                     'block_type': text_block['block_type']
                 }
         
-        # Convert sets to sorted lists for JSON serialization
+        # Process and expand URLs
+        processed = UrlProcessor.process_urls(sorted(all_urls))
+        expanded = UrlProcessor.batch_expand_urls(processed, delay=0)
+        expanded = UrlProcessor.fix_url_expansions(expanded)
+
         return {
-            'urls': sorted(list(all_urls)),
+            'urls': expanded,
             'ip_addresses': sorted(list(all_ips)),
             'domains': sorted(list(all_domains)),
             'statistics': {
-                'total_urls': len(all_urls),
+                'total_urls': len(expanded),
                 'total_ips': len(all_ips),
                 'total_domains': len(all_domains),
                 'sources_with_artifacts': len(sources_breakdown),

--- a/parse_email/url/__init__.py
+++ b/parse_email/url/__init__.py
@@ -1,0 +1,7 @@
+"""URL processing utilities package."""
+
+from .validator import UrlValidator
+from .decoder import UrlDecoder
+from .processor import UrlProcessor
+
+__all__ = ["UrlValidator", "UrlDecoder", "UrlProcessor"]

--- a/parse_email/url/decoder.py
+++ b/parse_email/url/decoder.py
@@ -1,0 +1,40 @@
+"""Utilities for decoding wrapped URLs such as Microsoft SafeLinks and Proofpoint URLs."""
+
+import logging
+import urllib.parse
+
+logger = logging.getLogger(__name__)
+
+class UrlDecoder:
+    """URL decoder utilities."""
+
+    @staticmethod
+    def decode_safelinks(url: str) -> str:
+        """Decode Microsoft SafeLinks URLs."""
+        if not url:
+            return url
+        try:
+            parsed = urllib.parse.urlparse(url)
+            query = urllib.parse.parse_qs(parsed.query)
+            target = query.get('url') or query.get('target')
+            if target:
+                return target[0]
+        except Exception as e:  # pragma: no cover - log warning
+            logger.warning(f"Error decoding SafeLinks URL {url}: {str(e)}")
+        return url
+
+    @staticmethod
+    def decode_proofpoint_urls(url: str) -> str:
+        """Decode Proofpoint URL Defense links."""
+        if not url:
+            return url
+        try:
+            parsed = urllib.parse.urlparse(url)
+            query = urllib.parse.parse_qs(parsed.query)
+            if 'u' in query:
+                encoded = query['u'][0]
+                decoded = urllib.parse.unquote(encoded)
+                return decoded
+        except Exception as e:  # pragma: no cover - log warning
+            logger.warning(f"Error decoding Proofpoint URL {url}: {str(e)}")
+        return url

--- a/parse_email/url/processor.py
+++ b/parse_email/url/processor.py
@@ -1,0 +1,184 @@
+"""URL processor module for high-level URL processing operations."""
+
+import logging
+import requests
+import time
+import urllib.parse
+from .validator import UrlValidator
+from .decoder import UrlDecoder
+
+logger = logging.getLogger(__name__)
+
+class UrlProcessor:
+    """Class for high-level URL processing operations including expansion,
+    deduplication, and unified processing."""
+
+    @staticmethod
+    def expand_url(url: str, timeout: int = 5, max_redirects: int = 10) -> str:
+        """Expand a shortened URL by following redirects."""
+        if not url or not UrlValidator.is_url_shortened(url):
+            return url
+
+        logger.debug(f"Expanding shortened URL: {url}")
+
+        try:
+            if not (url.startswith('http://') or url.startswith('https://')):
+                url = 'http://' + url
+
+            session = requests.Session()
+            response = session.head(
+                url,
+                allow_redirects=True,
+                timeout=timeout,
+                headers={'User-Agent': 'Mozilla/5.0'}
+            )
+            expanded_url = response.url
+            logger.debug(f"URL expanded to: {expanded_url}")
+            return expanded_url
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"Error expanding URL {url}: {str(e)}")
+            if hasattr(e, 'response') and e.response is not None:
+                return e.response.url
+            if hasattr(e, 'request'):
+                return e.request.url
+            if url.startswith('https://'):
+                fallback_url = url.replace('https://', 'http://', 1)
+                logger.debug(f"Retrying with HTTP: {fallback_url}")
+                try:
+                    response = session.head(fallback_url, allow_redirects=True, timeout=timeout)
+                    return response.url
+                except requests.RequestException:
+                    pass
+        return url
+
+    @staticmethod
+    def batch_expand_urls(urls, delay: float = 0.5):
+        """Expand a batch of shortened URLs to their final destinations."""
+        if not urls:
+            return urls
+
+        logger.debug(f"Batch expanding {len(urls)} URLs")
+        expanded_urls = []
+        for url_obj in urls:
+            if isinstance(url_obj, dict) and 'original_url' in url_obj:
+                expanded_url_obj = url_obj.copy()
+                if expanded_url_obj.get('is_shortened', False):
+                    expanded = UrlProcessor.expand_url(expanded_url_obj['original_url'])
+                    if expanded and expanded != expanded_url_obj['original_url']:
+                        expanded_url_obj['expanded_url'] = expanded
+                    else:
+                        expanded_url_obj['expanded_url'] = 'Not Applicable'
+                else:
+                    expanded_url_obj['expanded_url'] = 'Not Applicable'
+                expanded_urls.append(expanded_url_obj)
+                if delay > 0 and expanded_url_obj.get('is_shortened', False):
+                    time.sleep(delay)
+            else:
+                expanded_urls.append(url_obj)
+        return expanded_urls
+
+    @staticmethod
+    def process_urls(urls):
+        """Process a list of URLs consistently to deduplicate, decode wrapped links, and identify shortened URLs."""
+        if not urls:
+            return []
+        logger.debug(f"Processing {len(urls)} URLs")
+        processed_urls = []
+        seen_urls = set()
+
+        for url in urls:
+            url_str = url if isinstance(url, str) else url.get('original_url', '')
+            if not url_str:
+                continue
+            if url_str in seen_urls:
+                continue
+            if UrlValidator.is_image_url(url_str):
+                logger.debug(f"Skipping image URL: {url_str}")
+                continue
+            if 'safelinks.protection.outlook.com' in url_str:
+                decoded = UrlDecoder.decode_safelinks(url_str)
+                logger.debug(f"Decoded SafeLink: {url_str} -> {decoded}")
+                if decoded in seen_urls:
+                    continue
+                url_str = decoded
+            elif 'urldefense.com' in url_str:
+                decoded = UrlDecoder.decode_proofpoint_urls(url_str)
+                logger.debug(f"Decoded Proofpoint URL: {url_str} -> {decoded}")
+                if decoded in seen_urls:
+                    continue
+                url_str = decoded
+
+            seen_urls.add(url_str)
+            url_obj = {'original_url': url_str}
+            if isinstance(url, dict):
+                if 'is_shortened' in url:
+                    url_obj['is_shortened'] = url['is_shortened']
+                if 'expanded_url' in url and url['expanded_url'] != url_str:
+                    url_obj['expanded_url'] = url['expanded_url']
+
+            if 'is_shortened' not in url_obj:
+                url_obj['is_shortened'] = UrlValidator.is_url_shortened(url_str)
+
+            if not url_obj['is_shortened']:
+                url_obj['expanded_url'] = 'Not Applicable'
+            elif 'expanded_url' not in url_obj:
+                url_obj['expanded_url'] = url_str
+
+            processed_urls.append(url_obj)
+        return processed_urls
+
+    @staticmethod
+    def dedupe_to_base_urls(url_list):
+        """Deduplicate non-shortened URLs by their base domain, keeping shortened URLs intact."""
+        logger.debug(f"Deduplicating {len(url_list)} URLs")
+        seen_bases = set()
+        deduped = []
+        for url_obj in url_list:
+            if not isinstance(url_obj, dict) or 'original_url' not in url_obj:
+                continue
+            if url_obj.get('is_shortened', False):
+                deduped.append(url_obj)
+                continue
+            try:
+                parsed = urllib.parse.urlparse(url_obj['original_url'])
+                base = f"{parsed.scheme}://{parsed.netloc}"
+                if base not in seen_bases:
+                    seen_bases.add(base)
+                    deduped.append({
+                        'original_url': base,
+                        'is_shortened': False,
+                        'expanded_url': url_obj.get('expanded_url', 'Not Applicable')
+                    })
+            except Exception as e:
+                logger.warning(f"Error deduplicating URL {url_obj['original_url']}: {str(e)}")
+                deduped.append(url_obj)
+        logger.debug(f"Final deduplicated URL count: {len(deduped)}")
+        return deduped
+
+    @staticmethod
+    def fix_url_expansions(urls):
+        """Ensure expanded_url is set only for shortened URLs."""
+        fixed = []
+        for url in urls:
+            if isinstance(url, dict):
+                fixed_url = url.copy()
+                if not fixed_url.get('is_shortened', False):
+                    fixed_url['expanded_url'] = 'Not Applicable'
+                elif fixed_url.get('expanded_url') == fixed_url.get('original_url'):
+                    fixed_url['expanded_url'] = 'Not Applicable'
+                fixed.append(fixed_url)
+            else:
+                fixed.append(url)
+        return fixed
+
+    @staticmethod
+    def extract_urls_from_attachments(attachments):
+        """Extract URLs from email attachments."""
+        attachment_urls = []
+        for attachment in attachments:
+            if 'urls' in attachment:
+                attachment_urls.extend(attachment['urls'])
+                attachment_copy = attachment.copy()
+                del attachment_copy['urls']
+        logger.debug(f"Extracted {len(attachment_urls)} URLs from attachments")
+        return attachment_urls

--- a/parse_email/url/validator.py
+++ b/parse_email/url/validator.py
@@ -1,0 +1,81 @@
+"""
+URL validator module for validating, cleaning, and normalizing URLs.
+"""
+
+import logging
+import re
+import urllib.parse
+
+logger = logging.getLogger(__name__)
+
+class UrlValidator:
+    """Class for URL validation operations including cleaning, checking if a URL
+    is shortened, and identifying image URLs."""
+
+    # List of known URL shortener domains
+    URL_SHORTENER_PROVIDERS = [
+        "bit.ly", "t.co", "goo.gl", "ow.ly", "tinyurl.com", "is.gd", "buff.ly",
+        "rebrandly.com", "cutt.ly", "bl.ink", "snip.ly", "su.pr", "lnkd.in",
+        "fb.me", "cli.gs", "sh.st", "mcaf.ee", "yourls.org", "v.gd", "s.id",
+        "t.ly", "tiny.cc", "qlink.me", "po.st", "short.io", "shorturl.at",
+        "aka.ms", "tr.im", "bit.do", "git.io", "adf.ly", "qr.ae", "tny.im",
+        "x.co", "d.pr", "rb.gy", "vk.cc", "t1p.de", "chilp.it", "ouo.io",
+        "zi.ma", "pd.am", "hyperurl.co", "tiny.ie", "qps.ru", "l.ead.me",
+        "shorte.st"
+    ]
+
+    # Image file extensions
+    IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.svg', '.webp', '.tiff']
+
+    @staticmethod
+    def clean_url(url: str) -> str:
+        """Clean a URL by removing trailing punctuation and normalizing."""
+        if not url:
+            return url
+
+        while url and url[-1] in '.,;:!?)]}\'"':
+            url = url[:-1]
+
+        try:
+            parsed = urllib.parse.urlparse(url)
+            if parsed.scheme and parsed.netloc:
+                return urllib.parse.urlunparse(parsed)
+        except Exception as e:  # pragma: no cover - log warning
+            logger.warning(f"Error normalizing URL {url}: {str(e)}")
+
+        return url
+
+    @staticmethod
+    def is_url_shortened(url: str) -> bool:
+        """Check if a URL is likely to be shortened."""
+        if not url:
+            return False
+
+        try:
+            parsed = urllib.parse.urlparse(url)
+            domain = parsed.netloc.lower()
+
+            if any(domain == shortener or domain.endswith('.' + shortener)
+                   for shortener in UrlValidator.URL_SHORTENER_PROVIDERS):
+                return True
+
+            if parsed.path and len(parsed.path) <= 10 and re.match(r'^/[a-zA-Z0-9]+$', parsed.path):
+                return True
+        except Exception as e:  # pragma: no cover - log warning
+            logger.warning(f"Error checking if URL is shortened: {str(e)}")
+
+        return False
+
+    @staticmethod
+    def is_image_url(url: str) -> bool:
+        """Determine if a URL points to an image based on its extension."""
+        if not url:
+            return False
+
+        try:
+            parsed = urllib.parse.urlparse(url)
+            path = parsed.path.lower()
+            return any(path.endswith(ext) for ext in UrlValidator.IMAGE_EXTENSIONS)
+        except Exception as e:  # pragma: no cover - log warning
+            logger.warning(f"Error checking if URL is an image: {str(e)}")
+            return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,9 @@ chardet>=5.0.0
 # Note: Current implementation uses regex, but urlextract could be added for better accuracy
 # urlextract>=1.8.0
 
+# Required for URL expansion features
+requests>=2.0.0
+
 # Development/Testing dependencies (uncomment if needed)
 # pytest>=7.0.0
 # pytest-cov>=4.0.0


### PR DESCRIPTION
## Summary
- add URL processing utilities with short URL detection and expansion
- integrate URL processing into email parser
- update CLI to display sample URLs using new structure
- expose URL utilities in package init
- add requests dependency for expansion

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m parse_email.cli -h` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685d7105d0188324b4e0378b9ef311e5