### PR TITLE
Fix recursive handling of multipart parts

### DIFF
--- a/parse_email/email_parser.py
+++ b/parse_email/email_parser.py
@@ -603,6 +603,13 @@ class EmailParser:
                     else:
                         logger.debug(f"{'  ' * depth}    Not actually multipart or no sub-parts")
 
+                # Recurse into any multipart container
+                if hasattr(part, 'is_multipart') and part.is_multipart():
+                    logger.debug(f"{'  ' * depth}    Recursing into multipart part: {content_type}")
+                    for sub_block in self._walk_message(part, depth + 1):
+                        yield sub_block
+                    continue
+
                 # Decode payload first for all processing
                 payload = part.get_payload(decode=True) or b''
 


### PR DESCRIPTION
## Summary
- fix `_walk_message` to recurse into multipart parts to ensure text/plain and text/html content inside nested multiparts are parsed

## Testing
- `python3 -m py_compile parse_email/email_parser.py`

------
https://chatgpt.com/codex/tasks/task_e_685da3dfe0c48324a18b26a4831e8607