### PR TITLE
Remove optional dependency checks

### DIFF
--- a/parse_email/cli.py
+++ b/parse_email/cli.py
@@ -2,7 +2,8 @@
 import json
 import argparse
 import logging
-from .email_parser import EmailParser
+import importlib.util
+import sys
 
 def main():
     parser = argparse.ArgumentParser(description='Email Content Parser (Standard Library + Binary Support + Artifact Extraction)')
@@ -25,37 +26,16 @@ def main():
         filename=args.log_file,
         format='%(asctime)s %(levelname)s %(name)s: %(message)s'
     )
-    
-    # Check for optional dependencies
-    print("🔍 Checking optional dependencies:")
-    try:
-        import extract_msg
-        print("  ✅ extract_msg: Available (can parse .msg files)")
-    except ImportError:
-        print("  ❌ extract_msg: Not available (install with: pip install extract_msg)")
-    
-    try:
-        from tnefparse import TNEF
-        print("  ✅ tnefparse: Available (can parse TNEF/winmail.dat files)")
-    except ImportError:
-        print("  ❌ tnefparse: Not available (install with: pip install tnefparse)")
-    
-    try:
-        import chardet
-        print("  ✅ chardet: Available (improves charset detection)")
-    except ImportError:
-        print("  ❌ chardet: Not available (install with: pip install chardet)")
-    
-    print("\n🎯 Features:")
-    print("  • Detects .msg/.tnef files by signature (not MIME type)")
-    print("  • Works even when attachments are mislabeled as 'application/octet-stream'")
-    print("  • Gracefully falls back to raw binary if libraries unavailable")
-    print("  • Improved charset handling with fallback detection")
-    print("  • Optional raw content storage for forensic analysis")
-    print("  • 🆕 Extracts URLs, IP addresses, and domains from all text content")
-    print("  • 🆕 Handles HTML content and decodes entities")
-    print("  • 🆕 Provides detailed artifact statistics and source breakdown")
-    print()
+
+    # Ensure required dependencies are available
+    required = ['extract_msg', 'tnefparse', 'chardet', 'tldextract', 'requests']
+    missing = [m for m in required if importlib.util.find_spec(m) is None]
+    if missing:
+        print('Missing required dependencies: ' + ', '.join(missing), file=sys.stderr)
+        print('Please install the missing packages and try again.', file=sys.stderr)
+        sys.exit(1)
+
+    from .email_parser import EmailParser
     
     # Parse all files
     results = []
@@ -171,7 +151,6 @@ def main():
         
         if args.output is None:
             print(f"\n💡 Tip: Use -o filename.json to save full results to a file")
-            print(f"💡 To parse binary formats, install: pip install extract_msg tnefparse")
 
 
 if __name__ == "__main__":

--- a/parse_email/url/processor.py
+++ b/parse_email/url/processor.py
@@ -4,10 +4,7 @@ import logging
 import time
 import urllib.parse
 
-try:
-    import requests  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
-    requests = None
+import requests  # type: ignore
 from .validator import UrlValidator
 from .decoder import UrlDecoder
 
@@ -21,10 +18,6 @@ class UrlProcessor:
     def expand_url(url: str, timeout: int = 5, max_redirects: int = 10) -> str:
         """Expand a shortened URL by following redirects."""
         if not url or not UrlValidator.is_url_shortened(url):
-            return url
-
-        if requests is None:
-            logger.debug("requests library not available; skipping URL expansion")
             return url
 
         logger.debug(f"Expanding shortened URL: {url}")
@@ -45,7 +38,7 @@ class UrlProcessor:
             return expanded_url
         except Exception as e:  # pragma: no cover - network errors
             logger.warning(f"Error expanding URL {url}: {str(e)}")
-            if requests is not None and isinstance(e, requests.exceptions.RequestException):
+            if isinstance(e, requests.exceptions.RequestException):
                 if hasattr(e, 'response') and e.response is not None:
                     return e.response.url
                 if hasattr(e, 'request'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,6 @@
 # Email Parser Requirements
-# Core functionality works with Python standard library only
-# Optional dependencies enhance parsing capabilities
-
-# Optional: Enhanced MSG file parsing (Outlook .msg files)
-# Enables conversion of MSG files to RFC822 format for full parsing
 extract-msg>=0.41.0
-
-# Optional: TNEF parsing (winmail.dat files)
-# Enables extraction of attachments from TNEF containers
 tnefparse>=1.3.0
-
-# Optional: Validate domains using TLD lists
 tldextract>=3.4.0
-
-# Optional: Improved charset detection
-# Provides better text encoding detection for email content
 chardet>=5.0.0
-
-# Optional: URL extraction enhancement (if you want more robust URL extraction)
-# Note: Current implementation uses regex, but urlextract could be added for better accuracy
-# urlextract>=1.8.0
-
-# Required for URL expansion features
 requests>=2.0.0
-
-# Development/Testing dependencies (uncomment if needed)
-# pytest>=7.0.0
-# pytest-cov>=4.0.0


### PR DESCRIPTION
## Summary
- make extract_msg, tnefparse, chardet, tldextract and requests required
- drop optional dependency checks from CLI and enforce presence
- remove fallbacks for missing libraries in parser
- simplify requirements list

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dfb4c03288324a28dca06589c30b7