### PR TITLE
Fix artifact extraction from MIME parts

### DIFF
--- a/parse_email/email_parser.py
+++ b/parse_email/email_parser.py
@@ -855,6 +855,9 @@ class EmailParser:
                         'depth': depth
                     }
 
+                    # Store extracted text for artifact collection
+                    mime_part_data['content'] = text
+
 
                     if pdf_text:
                         mime_part_data['pdf_text'] = pdf_text


### PR DESCRIPTION
## Summary
- ensure decoded text from MIME parts is included for artifact extraction

## Testing
- `python -m parse_email.cli --help` *(fails: ModuleNotFoundError: No module named 'tldextract')*
- `pip install -r requirements.txt` *(fails to install dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685e09f414608324a7f90581116d3da0