### PR TITLE
Add text_only field for HTML content

### DIFF
--- a/parse_email/email_parser.py
+++ b/parse_email/email_parser.py
@@ -857,6 +857,8 @@ class EmailParser:
                     # Store extracted text only when it's actually text.
                     if encoding != 'base64':
                         mime_part_data['content'] = text
+                        if content_type == 'text/html':
+                            mime_part_data['text_only'] = self._clean_html(text)
 
 
                     if pdf_text:
@@ -970,6 +972,8 @@ class EmailParser:
 
                 if encoding != 'base64':
                     email_body_data['content'] = text
+                    if content_type == 'text/html':
+                        email_body_data['text_only'] = self._clean_html(text)
                 
                 
                 # Collect text content for artifact extraction


### PR DESCRIPTION
## Summary
- add plain text extraction for HTML MIME parts and bodies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e12f2060c832499dee364a909464a