### PR TITLE
Sanitize text_only output

### DIFF
--- a/parse_email/email_parser.py
+++ b/parse_email/email_parser.py
@@ -216,10 +216,18 @@ class EmailParser:
 
         # Decode HTML entities
         text = html.unescape(text)
-        
+
         # Clean up whitespace
         text = ' '.join(text.split())
-        
+
+        # Normalize so accents are combined and strip invisible characters
+        import unicodedata
+        text = unicodedata.normalize('NFC', text)
+        text = ''.join(
+            ch for ch in text
+            if unicodedata.category(ch)[0] not in ('C', 'M')
+        )
+
         return text
     
     def _extract_artifacts_from_text(self, text: str) -> Dict[str, Set[str]]:


### PR DESCRIPTION
## Summary
- remove invisible control characters when cleaning HTML
- normalize unicode and strip marks

## Testing
- `python -m py_compile parse_email/email_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_685e1427d8648324b5065ed3f423fa63