### PR TITLE
Implement forensics mode & plain text output

### DIFF
--- a/parse_email/cli.py
+++ b/parse_email/cli.py
@@ -17,6 +17,8 @@ def main():
                        help='Extract image content (otherwise only metadata is kept)')
     parser.add_argument('--include-large-images', action='store_true',
                        help='Include large images in output (may create very large files)')
+    parser.add_argument('--forensics_mode', action='store_true',
+                       help='Preserve full content details for forensics')
     parser.add_argument('--log-file', help='Write debug log to specified file')
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
 
@@ -53,7 +55,7 @@ def main():
             print(f"\n📧 Parsing: {file_path}")
             print("=" * 60)
             
-            result = email_parser.parse_file(file_path)
+            result = email_parser.parse_file(file_path, forensics_mode=args.forensics_mode)
             results.append(result)
             
             if 'error' not in result:

--- a/tests/test_forensics_mode.py
+++ b/tests/test_forensics_mode.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import pytest
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT_DIR)
+
+from parse_email.email_parser import EmailParser
+
+SIMPLE_EMAIL = b"Subject: Hello\n\nWorld"
+
+
+def test_content_truncated_without_forensics():
+    parser = EmailParser()
+    result = parser.parse(SIMPLE_EMAIL, forensics_mode=False)
+    assert "World" in result["plain_text"]
+    assert result["content"] == (
+        "Original content truncated for brevity. Run with --forensics_mode to get full key value pairs."
+    )
+
+
+def test_content_preserved_with_forensics():
+    parser = EmailParser()
+    result = parser.parse(SIMPLE_EMAIL, forensics_mode=True)
+    assert isinstance(result["content"], list)
+    assert "World" in result["plain_text"]


### PR DESCRIPTION
## Summary
- support `--forensics_mode` CLI flag
- add `forensics_mode` parameter in parser
- build `plain_text` output from collected blocks
- truncate `content` unless `--forensics_mode` is used
- test the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863399728ac83248d8420aec17c911b