### PR TITLE
Use html2text for HTML cleaning

### DIFF
--- a/parse_email/email_parser.py
+++ b/parse_email/email_parser.py
@@ -16,7 +16,7 @@ import tempfile
 import os
 import re
 import ipaddress
-from .html_cleaner import EnhancedHtmlCleaner
+from .html_cleaner import PhishingEmailHtmlCleaner
 from pathlib import Path
 from typing import List, Dict, Any, Iterator, Optional, Set, Tuple
 import base64
@@ -229,8 +229,8 @@ class EmailParser:
         return '\n'.join(cleaned_lines).strip()
 
     def _clean_html(self, text: str) -> str:
-        """Extract plain text from HTML with invisible character removal."""
-        return EnhancedHtmlCleaner.clean_html(text, aggressive_cleaning=True)
+        """Extract plain text from HTML for artifact extraction."""
+        return PhishingEmailHtmlCleaner.clean_html(text, aggressive_cleaning=True)
     
     def _extract_artifacts_from_text(self, text: str) -> Dict[str, Set[str]]:
         """Extract URLs, IPs, and domains from text content"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ chardet>=5.0.0
 requests>=2.0.0
 pdfminer.six>=20221105
 beautifulsoup4>=4.9.0
+html2text>=2020.1.16

--- a/tests/test_html_cleaner.py
+++ b/tests/test_html_cleaner.py
@@ -6,7 +6,7 @@ MODULE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'par
 spec = importlib.util.spec_from_file_location('html_cleaner', MODULE_PATH)
 html_cleaner = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(html_cleaner)
-EnhancedHtmlCleaner = html_cleaner.EnhancedHtmlCleaner
+PhishingEmailHtmlCleaner = html_cleaner.PhishingEmailHtmlCleaner
 
 
 @pytest.mark.parametrize("input_html,expected", [
@@ -16,4 +16,4 @@ EnhancedHtmlCleaner = html_cleaner.EnhancedHtmlCleaner
     ("<p>\u201Cdouble\u201D</p>", '"double"'),
 ])
 def test_unicode_cleaning(input_html, expected):
-    assert EnhancedHtmlCleaner.clean_html(input_html) == expected
+    assert PhishingEmailHtmlCleaner.clean_html(input_html) == expected


### PR DESCRIPTION
## Summary
- switch EnhancedHtmlCleaner to PhishingEmailHtmlCleaner built on html2text
- integrate new cleaner in EmailParser
- update unit tests for new cleaner
- add html2text to requirements

## Testing
- `pip install html2text`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864036d9cf4832480da63f6aa272663