### PR TITLE
Fix hidden HTML cleaning and unicode removal

### DIFF
--- a/tests/test_html_cleaner.py
+++ b/tests/test_html_cleaner.py
@@ -17,3 +17,14 @@ PhishingEmailHtmlCleaner = html_cleaner.PhishingEmailHtmlCleaner
 ])
 def test_unicode_cleaning(input_html, expected):
     assert PhishingEmailHtmlCleaner.clean_html(input_html) == expected
+
+
+def test_hidden_div_removed():
+    hidden_chars = "\u2007\u034f\u00ad" * 60
+    html = f'<div style="display:none">{hidden_chars}</div><p>Visible</p>'
+    assert PhishingEmailHtmlCleaner.clean_html(html) == "Visible"
+
+
+def test_combining_mark_removed():
+    html = "<p>A\u034fB</p>"
+    assert PhishingEmailHtmlCleaner.clean_html(html) == "AB"

--- a/tests/test_html_leakage_fixes.py
+++ b/tests/test_html_leakage_fixes.py
@@ -59,8 +59,6 @@ Content-Type: text/html; charset=utf-8
     assert 'suspended' in plain_text.lower()
     assert 'verify' in plain_text.lower()
     print("✓ Core message content preserved")
-    
-    return True
 
 def test_nested_html_cleaning():
     """Test HTML cleaning in nested email structures."""
@@ -118,8 +116,6 @@ Content-Type: text/html; charset=utf-8
     urls_found = artifacts.get('statistics', {}).get('total_urls', 0)
     assert urls_found >= 2, f"Expected at least 2 URLs, found {urls_found}"
     print(f"✓ URLs extracted from nested content: {urls_found}")
-    
-    return True
 
 def test_mislabeled_html_content():
     """Test detection of HTML content with incorrect MIME type."""
@@ -162,8 +158,6 @@ Content-Type: text/plain; charset=utf-8
     urls_found = artifacts.get('statistics', {}).get('total_urls', 0)
     assert urls_found >= 1, f"Expected at least 1 URL, found {urls_found}"
     print(f"✓ URLs extracted: {urls_found}")
-    
-    return True
 
 def test_complex_nested_structure():
     """Test deeply nested email structure with mixed content types."""
@@ -237,8 +231,6 @@ Content-Type: text/html
     assert 'fetch(' not in plain_text
     assert 'display:none' not in plain_text
     print("✓ Malicious content removed from nested structure")
-    
-    return True
 
 def run_all_tests():
     """Run all HTML leakage tests."""


### PR DESCRIPTION
## Summary
- pre-strip hidden elements before html2text conversion
- correct logic for removing mark characters
- validate cleaning to remove remaining invisible chars
- add tests covering hidden divs and mark characters
- remove return statements in html leakage tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640bdb80d48324ae0f63606b1459c9