### PR TITLE
Enforce html_text truncation

### DIFF
--- a/phishing_email_parser/main_parser.py
+++ b/phishing_email_parser/main_parser.py
@@ -162,7 +162,12 @@ class PhishingEmailParser:
         # Extract URLs from body, attachments, and images
         urls = self._extract_all_urls(layer["body"], layer["attachments"], images)
         layer["urls"] = urls
-        
+
+        # Truncate html_text to keep output concise
+        html_text = layer["body"].get("html_text")
+        if html_text:
+            layer["body"]["html_text"] = html_text[:100]
+
         return layer
     
     def _extract_headers(self, msg: Message) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- truncate `html_text` to 100 chars in each message layer

## Testing
- `pytest -q`
- `python -m py_compile phishing_email_parser/main_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68647bd665d0832487684c7d6d13b5af