### PR TITLE
Handle HTML mislabeled as plain text

### DIFF
--- a/phishing_email_parser/core/html_cleaner.py
+++ b/phishing_email_parser/core/html_cleaner.py
@@ -69,6 +69,20 @@ class PhishingEmailHtmlCleaner:
         '\uFFA0',
     }
 
+    @classmethod
+    def contains_html(cls, text: str) -> bool:
+        """Heuristically determine if a string contains HTML tags."""
+        if not text or '<' not in text:
+            return False
+        # Quick regex check for any HTML-like tags
+        if re.search(r'<[^>]+>', text):
+            try:
+                soup = BeautifulSoup(text, "html.parser")
+                return bool(soup.find())
+            except Exception:
+                return False
+        return False
+
     CONTROL_CHAR_RANGES = [
         (0x0000, 0x001F),
         (0x007F, 0x009F),

--- a/phishing_email_parser/main_parser.py
+++ b/phishing_email_parser/main_parser.py
@@ -210,8 +210,15 @@ class PhishingEmailParser:
                 if content_type == "text/plain" and not part.get_filename():
                     plain_content = get_content_safe(part)
                     if plain_content:
-                        body_data["plain_text"] = plain_content
-                        body_data["has_plain"] = True
+                        if PhishingEmailHtmlCleaner.contains_html(plain_content):
+                            body_data["html_text"] = plain_content
+                            body_data["has_html"] = True
+                            body_data["converted_text"] = PhishingEmailHtmlCleaner.clean_html(
+                                plain_content, aggressive_cleaning=True
+                            )
+                        else:
+                            body_data["plain_text"] = plain_content
+                            body_data["has_plain"] = True
                 elif content_type == "text/html" and not part.get_filename():
                     html_content = get_content_safe(part)
                     if html_content:
@@ -226,8 +233,15 @@ class PhishingEmailParser:
             content = get_content_safe(msg)
             if content:
                 if content_type == "text/plain":
-                    body_data["plain_text"] = content
-                    body_data["has_plain"] = True
+                    if PhishingEmailHtmlCleaner.contains_html(content):
+                        body_data["html_text"] = content
+                        body_data["has_html"] = True
+                        body_data["converted_text"] = PhishingEmailHtmlCleaner.clean_html(
+                            content, aggressive_cleaning=True
+                        )
+                    else:
+                        body_data["plain_text"] = content
+                        body_data["has_plain"] = True
                 elif content_type == "text/html":
                     body_data["html_text"] = content
                     body_data["has_html"] = True


### PR DESCRIPTION
## Summary
- detect HTML tags in text/plain parts
- parse mislabeled HTML using the existing cleaner

## Testing
- `python -m pip install --quiet -r requirements.txt`
- `python -m compileall -q phishing_email_parser examples`
- `PYTHONPATH=. python examples/example_usage.py sample_plain_html.eml | head -n 20`
- `PYTHONPATH=. python - <<'PY'
from phishing_email_parser.main_parser import PhishingEmailParser
import json
with PhishingEmailParser() as p:
    result = p.parse_email_file('sample_plain_html.eml')
print(json.dumps(result['message_layers'][0]['body'], indent=2))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68648802a47c8324b0460e8dacd2f2c3