### PR TITLE
Update MIME walker with rfc822 decoding

### DIFF
--- a/phishing_email_parser/core/__init__.py
+++ b/phishing_email_parser/core/__init__.py
@@ -1,6 +1,6 @@
 """Core email processing modules."""
-from .carrier_detector import is_carrier, CARRIER_PATTERNS
+from .carrier_detector import is_carrier, CARRIER_PATTERNS, detect_vendor
 from .html_cleaner import PhishingEmailHtmlCleaner
 from .mime_walker import walk_layers
 
-__all__ = ["is_carrier", "CARRIER_PATTERNS", "PhishingEmailHtmlCleaner", "walk_layers"]
+__all__ = ["is_carrier", "CARRIER_PATTERNS", "detect_vendor", "PhishingEmailHtmlCleaner", "walk_layers"]

--- a/phishing_email_parser/core/carrier_detector.py
+++ b/phishing_email_parser/core/carrier_detector.py
@@ -35,3 +35,9 @@ def is_carrier(msg: Message) -> Tuple[bool, Optional[str]]:  # noqa: D401 – no
         if re.search(pat_subj, subj, _re_flags) or re.search(pat_hdr, hdr_blob, _re_flags):
             return True, vendor
     return False, None
+
+
+def detect_vendor(msg: Message) -> Optional[str]:
+    """Return vendor tag if *msg* is a carrier email, otherwise ``None``."""
+    flag, vendor = is_carrier(msg)
+    return vendor if flag else None


### PR DESCRIPTION
## Summary
- add `detect_vendor` helper in `carrier_detector`
- export `detect_vendor`
- refactor `mime_walker.walk_layers` to decode `message/rfc822` attachments

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=. python examples/example_usage.py` *(fails: No module named 'html2text')*

------
https://chatgpt.com/codex/tasks/task_e_6866de610de48324bb7a59ced867bfb2