### PR TITLE
Fix import paths

### DIFF
--- a/phishing_email_parser/processing/attachment_processor.py
+++ b/phishing_email_parser/processing/attachment_processor.py
@@ -21,10 +21,10 @@ import tempfile
 import shutil
 
 # Import our modules - FIXED IMPORTS
-from .core.html_cleaner import PhishingEmailHtmlCleaner
-from .processing.attachment_processor import AttachmentProcessor
-from .processing.msg_converter import MSGConverter
-from .url_processing.processor import UrlProcessor
+from ..core.html_cleaner import PhishingEmailHtmlCleaner
+from .attachment_processor import AttachmentProcessor
+from .msg_converter import MSGConverter
+from ..url_processing.processor import UrlProcessor
 
 # For compatibility with original script functionality
 from PIL import Image

--- a/phishing_email_parser/test.py
+++ b/phishing_email_parser/test.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from processing.msg_converter import MSGConverter   # adjust import to your package layout
+from phishing_email_parser.processing.msg_converter import MSGConverter
 
 out_dir = Path("debug_artifacts").resolve()     # pick any folder you like
 out_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
## Summary
- fix package import paths in `attachment_processor.py`
- update test import path

## Testing
- `make fmt && make test && make lint` *(fails: No rule to make target)*
- `python -m py_compile phishing_email_parser/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68692d9f0f508324ab0433853063c318