### PR TITLE
Introduce config and custom error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ with PhishingEmailParser() as parser:
         body_text = layer['body']['final_text']
         urls = layer['urls']
         attachments = layer['attachments']
+
+# Custom configuration example
+from phishing_email_parser import ParserConfig
+
+config = ParserConfig(
+    suspicious_extensions=(".exe", ".zip"),
+)
+with PhishingEmailParser(config=config) as parser:
+    parser.parse_email_file("phishing.eml")
 ```
 
 ### Core Components Usage
@@ -313,6 +322,7 @@ phishing_email_parser/
 - **`AttachmentProcessor`**: Attachment handling and text extraction
 - **`MSGConverter`**: Microsoft Outlook MSG file conversion
 - **`UrlProcessor`**: URL extraction, expansion, and deduplication
+- **`ParserConfig`**: Optional configuration object to customise parser behaviour
 
 ## Security Considerations
 

--- a/phishing_email_parser/__init__.py
+++ b/phishing_email_parser/__init__.py
@@ -1,9 +1,17 @@
 """
 Phishing Email Parser Package
 """
+
 from .core.carrier_detector import CARRIER_PATTERNS, is_carrier
 from .core.html_cleaner import PhishingEmailHtmlCleaner
+from .config import ParserConfig
 from .main_parser import PhishingEmailParser
 
 __version__ = "1.0.0"
-__all__ = ["PhishingEmailParser", "is_carrier", "CARRIER_PATTERNS", "PhishingEmailHtmlCleaner"]
+__all__ = [
+    "PhishingEmailParser",
+    "ParserConfig",
+    "is_carrier",
+    "CARRIER_PATTERNS",
+    "PhishingEmailHtmlCleaner",
+]

--- a/phishing_email_parser/config.py
+++ b/phishing_email_parser/config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Configuration for the phishing email parser."""
+
+from dataclasses import dataclass, field
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class ParserConfig:
+    """Configuration options for :class:`PhishingEmailParser`."""
+
+    suspicious_extensions: Tuple[str, ...] = (
+        ".exe",
+        ".scr",
+        ".bat",
+        ".cmd",
+        ".com",
+        ".pif",
+        ".vbs",
+        ".js",
+        ".jar",
+        ".zip",
+        ".rar",
+        ".7z",
+        ".ace",
+        ".arj",
+        ".cab",
+        ".lzh",
+        ".tar",
+        ".gz",
+    )
+    text_extractable_types: Tuple[str, ...] = (
+        "application/pdf",
+        "text/plain",
+        "text/html",
+        "text/csv",
+        "application/rtf",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+
+
+DEFAULT_CONFIG = ParserConfig()

--- a/phishing_email_parser/exceptions.py
+++ b/phishing_email_parser/exceptions.py
@@ -1,0 +1,11 @@
+"""Custom exceptions for the phishing email parser."""
+
+from __future__ import annotations
+
+
+class EmailParserError(Exception):
+    """Base class for parser errors."""
+
+
+class AttachmentProcessingError(EmailParserError):
+    """Raised when attachment processing fails."""

--- a/phishing_email_parser/main_parser.py
+++ b/phishing_email_parser/main_parser.py
@@ -3,7 +3,7 @@
 Comprehensive phishing email parser for LLM analysis.
 
 This parser handles user-submitted phishing emails, detects carrier emails
-from security appliances and user submissions, recursively parses nested 
+from security appliances and user submissions, recursively parses nested
 structures, and outputs structured JSON for LLM analysis with enhanced
 carrier detection and content deduplication.
 """
@@ -41,26 +41,28 @@ from .core.mime_walker import walk_layers
 from .processing.attachment_processor import AttachmentProcessor
 from .processing.msg_converter import MSGConverter
 from .url_processing.processor import UrlProcessor
+from .config import DEFAULT_CONFIG, ParserConfig
+from .exceptions import AttachmentProcessingError, EmailParserError
 
 logger = logging.getLogger(__name__)
 
 
 class EmailContentDeduplicator:
     """Handles deduplication of email content during nested processing."""
-    
+
     def __init__(self):
         self.processed_content_hashes: Set[str] = set()
         self.processed_message_ids: Set[str] = set()
         self.layer_content_signatures: Dict[int, str] = {}
-    
+
     def generate_content_signature(self, msg: Message) -> str:
         """Generate a unique signature for email content."""
         # Combine key identifying fields
-        subject = msg.get('subject', '').strip()
-        from_addr = msg.get('from', '').strip()
-        date = msg.get('date', '').strip()
-        message_id = msg.get('message-id', '').strip()
-        
+        subject = msg.get("subject", "").strip()
+        from_addr = msg.get("from", "").strip()
+        date = msg.get("date", "").strip()
+        message_id = msg.get("message-id", "").strip()
+
         # Get a sample of body content for comparison
         body_sample = ""
         if msg.is_multipart():
@@ -80,131 +82,151 @@ class EmailContentDeduplicator:
                     body_sample = content[:500]
             except Exception:
                 pass
-        
+
         # Create signature from combined fields
         signature_data = f"{subject}|{from_addr}|{date}|{message_id}|{body_sample}"
-        return hashlib.sha256(signature_data.encode('utf-8')).hexdigest()[:16]
-    
+        return hashlib.sha256(signature_data.encode("utf-8")).hexdigest()[:16]
+
     def is_duplicate_content(self, msg: Message, current_depth: int) -> bool:
         """Check if this message content has already been processed."""
         # Check by Message-ID first (most reliable)
-        message_id = msg.get('message-id', '').strip()
+        message_id = msg.get("message-id", "").strip()
         if message_id and message_id in self.processed_message_ids:
             logger.debug(f"Duplicate detected by Message-ID: {message_id}")
             return True
-        
+
         # Check by content signature
         content_sig = self.generate_content_signature(msg)
         if content_sig in self.processed_content_hashes:
             logger.debug(f"Duplicate detected by content signature: {content_sig}")
             return True
-        
+
         # Check for identical content in parent layers
         for layer_depth, layer_sig in self.layer_content_signatures.items():
             if layer_depth < current_depth and layer_sig == content_sig:
-                logger.debug(f"Duplicate content found: layer {current_depth} matches layer {layer_depth}")
+                logger.debug(
+                    f"Duplicate content found: layer {current_depth} matches layer {layer_depth}"
+                )
                 return True
-        
+
         return False
-    
+
     def mark_as_processed(self, msg: Message, depth: int):
         """Mark this message as processed to prevent future duplicates."""
-        message_id = msg.get('message-id', '').strip()
+        message_id = msg.get("message-id", "").strip()
         if message_id:
             self.processed_message_ids.add(message_id)
-        
+
         content_sig = self.generate_content_signature(msg)
         self.processed_content_hashes.add(content_sig)
         self.layer_content_signatures[depth] = content_sig
-        
+
         logger.debug(f"Marked layer {depth} as processed (sig: {content_sig[:8]}...)")
 
 
 class PhishingEmailParser:
-    """Main parser for phishing emails submitted by users with enhanced carrier detection."""
-    
-    def __init__(self, temp_dir: Optional[str] = None):
-        """Initialize parser with optional temporary directory."""
+    """Main parser for phishing emails with enhanced carrier detection."""
+
+    def __init__(
+        self, temp_dir: Optional[str] = None, config: ParserConfig | None = None
+    ) -> None:
+        """Initialize the parser.
+
+        Args:
+            temp_dir: Optional path to a temporary directory. If ``None`` a new directory is created.
+            config: Optional parser configuration to customize behaviour.
+        """
+
         self.temp_dir = temp_dir or tempfile.mkdtemp(prefix="phishing_parser_")
-        self.attachment_processor = AttachmentProcessor(self.temp_dir)
+        self.config = config or DEFAULT_CONFIG
+        self.attachment_processor = AttachmentProcessor(self.temp_dir, self.config)
         self.msg_converter = MSGConverter()
-        
+
     def __enter__(self):
         return self
-        
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Clean up temporary directory."""
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir, ignore_errors=True)
-    
-    def parse_email_file(self, email_path: str) -> Dict[str, Any]:
+
+    def parse_email_file(self, email_path: str | Path) -> Dict[str, Any]:
         """
         Parse an email file (.eml or .msg) and return structured data.
-        
+
         Args:
             email_path: Path to email file
-            
+
         Returns:
             Dictionary with parsed email structure
         """
         email_path = Path(email_path)
-        
+
         if not email_path.exists():
             raise FileNotFoundError(f"Email file not found: {email_path}")
-            
+
+        if email_path.suffix.lower() not in {".eml", ".msg"}:
+            raise ValueError(
+                "Unsupported email file type. Only .eml and .msg are allowed"
+            )
+
         # Convert .msg to .eml if needed
-        if email_path.suffix.lower() == '.msg':
+        if email_path.suffix.lower() == ".msg":
             eml_path = self.msg_converter.convert_msg_to_eml(
-                str(email_path), 
-                self.temp_dir
+                str(email_path), self.temp_dir
             )
             email_path = Path(eml_path)
-        
-        # Parse the email
-        with open(email_path, 'rb') as f:
-            msg = BytesParser(policy=policy.default).parse(f)
-            
-        return self._parse_message_structure(msg, str(email_path.parent))
-    
 
-    def _parse_single_layer(self, msg: Message, depth: int, vendor_tag: Optional[str],
-                           output_dir: str) -> Dict[str, Any]:
+        # Parse the email
+        with open(email_path, "rb") as f:
+            msg = BytesParser(policy=policy.default).parse(f)
+
+        try:
+            return self._parse_message_structure(msg, str(email_path.parent))
+        except AttachmentProcessingError as exc:
+            raise EmailParserError(f"Attachment processing failed: {exc}") from exc
+
+    def _parse_single_layer(
+        self, msg: Message, depth: int, vendor_tag: Optional[str], output_dir: str
+    ) -> Dict[str, Any]:
         """Parse a single message layer with enhanced carrier detection."""
         logger.debug(f"Parsing layer {depth}, vendor: {vendor_tag}")
-        
+
         # Get enhanced carrier detection details
         vendor_tag_enhanced, carrier_details = detect_vendor_enhanced(msg)
-        
+
         # Use enhanced detection if it found something, otherwise use walk_layers result
         final_vendor_tag = vendor_tag_enhanced or vendor_tag
         analysis_priority = get_carrier_analysis_priority(final_vendor_tag)
-        
+
         layer = {
             "layer_depth": depth,
             "is_carrier_email": final_vendor_tag is not None,
             "carrier_vendor": final_vendor_tag,
             "carrier_details": carrier_details,
             "analysis_priority": analysis_priority,
-            "carrier_summary": format_carrier_summary(final_vendor_tag, carrier_details),
+            "carrier_summary": format_carrier_summary(
+                final_vendor_tag, carrier_details
+            ),
             "headers": self._extract_headers(msg),
             "body": self._extract_body(msg),
             "attachments": [],
             "images": [],
             "urls": [],
-            "nested_emails": []
+            "nested_emails": [],
         }
-        
+
         # Process attachments
         attachments = self.attachment_processor.process_attachments(msg, output_dir)
         if attachments:
             layer["attachments"] = attachments
         logger.debug("Layer %d - %d attachments processed", depth, len(attachments))
-        
+
         # Extract images with OCR
         images = self._extract_images_with_ocr(msg, output_dir)
         layer["images"] = images
         logger.debug("Layer %d - %d images processed", depth, len(images))
-        
+
         # Extract URLs from body, attachments, and images
         urls = self._extract_all_urls(layer["body"], layer["attachments"], images)
         layer["urls"] = urls
@@ -219,7 +241,7 @@ class PhishingEmailParser:
             layer["body"]["html_text"] = truncated
 
         return layer
-    
+
     def _extract_headers(self, msg: Message) -> Dict[str, Any]:
         """Extract relevant headers from message."""
         return {
@@ -232,27 +254,29 @@ class PhishingEmailParser:
             "message_id": self._clean_header_value(msg.get("message-id", "")),
             "reply_to": self._clean_header_value(msg.get("reply-to", "")),
             "return_path": self._clean_header_value(msg.get("return-path", "")),
-            "received": [self._clean_header_value(r) for r in (msg.get_all("received") or [])],
+            "received": [
+                self._clean_header_value(r) for r in (msg.get_all("received") or [])
+            ],
             "x_headers": {
-                k: self._clean_header_value(v) 
-                for k, v in msg.items() 
-                if k.lower().startswith('x-')
-            }
+                k: self._clean_header_value(v)
+                for k, v in msg.items()
+                if k.lower().startswith("x-")
+            },
         }
-    
+
     def _clean_header_value(self, value):
         """Clean header values by removing null terminators and other issues."""
         if not value:
             return ""
         if isinstance(value, bytes):
-            value = value.decode('utf-8', errors='replace')
+            value = value.decode("utf-8", errors="replace")
         if isinstance(value, str):
             # Remove null terminators and other control characters
-            value = value.rstrip('\x00').strip()
+            value = value.rstrip("\x00").strip()
             # Remove other common problematic characters
-            value = value.replace('\x00', '').replace('\r', '').replace('\n', ' ')
+            value = value.replace("\x00", "").replace("\r", "").replace("\n", " ")
         return value
-    
+
     def _extract_body(self, msg: Message) -> Dict[str, Any]:
         """Extract and process email body content."""
         body_data = {
@@ -260,44 +284,45 @@ class PhishingEmailParser:
             "html_text": "",
             "converted_text": "",
             "has_html": False,
-            "has_plain": False
+            "has_plain": False,
         }
-        
+
         def get_content_safe(part):
             """Safely get content from an email part."""
             try:
                 content = part.get_content()
                 # Clean the content of null bytes and other problematic characters
                 if isinstance(content, str):
-                    content = content.replace('\x00', '')
+                    content = content.replace("\x00", "")
                 return content
             except Exception as e:
                 logger.warning(f"Error getting content from email part: {e}")
                 return ""
-        
+
         if msg.is_multipart():
             for part in msg.walk():
                 content_type = part.get_content_type()
                 # FIXED: Clean content type
                 if content_type:
-                    content_type = content_type.rstrip('\x00').strip()
-                    
+                    content_type = content_type.rstrip("\x00").strip()
+
                 if content_type == "text/plain" and not part.get_filename():
                     plain_content = get_content_safe(part)
                     if plain_content:
                         if PhishingEmailHtmlCleaner.contains_html(plain_content):
                             body_data["html_text"] = plain_content
                             body_data["has_html"] = True
-                            body_data["converted_text"] = PhishingEmailHtmlCleaner.clean_html(
-                                plain_content, aggressive_cleaning=True
+                            body_data["converted_text"] = (
+                                PhishingEmailHtmlCleaner.clean_html(
+                                    plain_content, aggressive_cleaning=True
+                                )
                             )
                         else:
                             body_data["plain_text"] = plain_content
                             body_data["has_plain"] = True
                             # Skip if it looks like base64 encoded data
-                            if (
-                                len(body_data["plain_text"]) > 800
-                                and re.fullmatch(r"[A-Za-z0-9+/=\s]{800,}", body_data["plain_text"])
+                            if len(body_data["plain_text"]) > 800 and re.fullmatch(
+                                r"[A-Za-z0-9+/=\s]{800,}", body_data["plain_text"]
                             ):
                                 body_data["plain_text"] = ""
                 elif content_type == "text/html" and not part.get_filename():
@@ -306,31 +331,34 @@ class PhishingEmailParser:
                         body_data["html_text"] = html_content
                         body_data["has_html"] = True
                         # Convert HTML to plain text
-                        body_data["converted_text"] = PhishingEmailHtmlCleaner.clean_html(
-                            html_content, aggressive_cleaning=True
+                        body_data["converted_text"] = (
+                            PhishingEmailHtmlCleaner.clean_html(
+                                html_content, aggressive_cleaning=True
+                            )
                         )
         else:
             content_type = msg.get_content_type()
             # FIXED: Clean content type
             if content_type:
-                content_type = content_type.rstrip('\x00').strip()
-                
+                content_type = content_type.rstrip("\x00").strip()
+
             content = get_content_safe(msg)
             if content:
                 if content_type == "text/plain":
                     if PhishingEmailHtmlCleaner.contains_html(content):
                         body_data["html_text"] = content
                         body_data["has_html"] = True
-                        body_data["converted_text"] = PhishingEmailHtmlCleaner.clean_html(
-                            content, aggressive_cleaning=True
+                        body_data["converted_text"] = (
+                            PhishingEmailHtmlCleaner.clean_html(
+                                content, aggressive_cleaning=True
+                            )
                         )
                     else:
                         body_data["plain_text"] = content
                         body_data["has_plain"] = True
                         # Skip if it looks like base64 encoded data
-                        if (
-                            len(body_data["plain_text"]) > 800
-                            and re.fullmatch(r"[A-Za-z0-9+/=\s]{800,}", body_data["plain_text"])
+                        if len(body_data["plain_text"]) > 800 and re.fullmatch(
+                            r"[A-Za-z0-9+/=\s]{800,}", body_data["plain_text"]
                         ):
                             body_data["plain_text"] = ""
                 elif content_type == "text/html":
@@ -339,69 +367,72 @@ class PhishingEmailParser:
                     body_data["converted_text"] = PhishingEmailHtmlCleaner.clean_html(
                         content, aggressive_cleaning=True
                     )
-        
+
         # Use converted text if available, otherwise use plain text
         if body_data["converted_text"]:
             body_data["final_text"] = body_data["converted_text"]
         else:
             body_data["final_text"] = body_data["plain_text"]
-            
+
         return body_data
-    
-    def _extract_all_urls(self, body_data: Dict[str, Any], attachments: List[Dict], 
-                         images: List[Dict]) -> List[Dict]:
+
+    def _extract_all_urls(
+        self, body_data: Dict[str, Any], attachments: List[Dict], images: List[Dict]
+    ) -> List[Dict]:
         """Extract and process URLs from body, attachments, and images."""
         all_urls = []
-        
+
         # Extract URLs from email body
         body_text = body_data.get("final_text", "")
         if body_text:
             urls = self._extract_urls_from_text(body_text)
             all_urls.extend(urls)
-            
+
         # Extract URLs from HTML body if available
         html_text = body_data.get("html_text", "")
         if html_text:
             html_urls = self._extract_urls_from_html(html_text)
             all_urls.extend(html_urls)
-        
+
         # Extract URLs from attachments
         attachment_urls = UrlProcessor.extract_urls_from_attachments(attachments)
         all_urls.extend(attachment_urls)
-        
+
         # Extract URLs from OCR text in images
         for image in images:
             if image.get("ocr_text"):
                 image_urls = self._extract_urls_from_text(image["ocr_text"])
                 all_urls.extend(image_urls)
-        
+
         # Process and deduplicate URLs
         processed_urls = UrlProcessor.process_urls(all_urls)
         return processed_urls
-    
-    def _extract_images_with_ocr(self, msg: Message, output_dir: str) -> List[Dict[str, Any]]:
+
+    def _extract_images_with_ocr(
+        self, msg: Message, output_dir: str
+    ) -> List[Dict[str, Any]]:
         """Extract images and perform OCR (from original script functionality)."""
         images = []
         image_idx = 1
-        
+
         for part in msg.walk():
             ctype = part.get_content_type()
             if ctype.startswith("image/"):
                 content_id = part.get("Content-ID")
                 filename = part.get_filename() or f"image_{image_idx}.png"
-                
+
                 # FIXED: Strip null terminators and other problematic characters
                 if filename:
-                    filename = filename.rstrip('\x00').strip()
-                    
+                    filename = filename.rstrip("\x00").strip()
+
                 # FIXED: Clean content type
                 if ctype:
-                    ctype = ctype.rstrip('\x00').strip()
-                    
+                    ctype = ctype.rstrip("\x00").strip()
+
                 out_path = os.path.join(output_dir, filename)
                 payload = part.get_payload(decode=True)
                 ocr_text = None
-                
+
                 if payload:
                     # Save image to disk
                     try:
@@ -410,85 +441,91 @@ class PhishingEmailParser:
                     except Exception as e:
                         logger.warning(f"Error saving image {filename}: {e}")
                         out_path = None
-                    
+
                     # Perform OCR
                     try:
                         img = Image.open(BytesIO(payload))
-                        img = img.convert('L')  # Convert to grayscale
+                        img = img.convert("L")  # Convert to grayscale
                         ocr_text = pytesseract.image_to_string(img)
                         if ocr_text:
                             ocr_text = ocr_text.strip()
                     except Exception as e:
                         logger.warning(f"Error performing OCR on {filename}: {e}")
                         ocr_text = None
-                
+
                 # FIXED: Clean content_id of null bytes too
                 clean_content_id = None
                 if content_id:
-                    clean_content_id = content_id.rstrip('\x00').strip()
-                
-                images.append({
-                    "index": image_idx,
-                    "filename": filename,
-                    "disk_path": out_path,
-                    "content_id": clean_content_id,
-                    "content_type": ctype,  # Now cleaned
-                    "ocr_text": ocr_text,
-                    "size": len(payload) if payload else 0
-                })
+                    clean_content_id = content_id.rstrip("\x00").strip()
+
+                images.append(
+                    {
+                        "index": image_idx,
+                        "filename": filename,
+                        "disk_path": out_path,
+                        "content_id": clean_content_id,
+                        "content_type": ctype,  # Now cleaned
+                        "ocr_text": ocr_text,
+                        "size": len(payload) if payload else 0,
+                    }
+                )
                 image_idx += 1
-        
+
         return images
 
-    
     def _extract_urls_from_text(self, text: str) -> List[str]:
         """Extract URLs from plain text."""
         import re
-        
+
         # Pattern to match URLs
         url_pattern = re.compile(
-            r'https?://[^\s<>"{}|\\^`\[\]]+|www\.[^\s<>"{}|\\^`\[\]]+',
-            re.IGNORECASE
+            r'https?://[^\s<>"{}|\\^`\[\]]+|www\.[^\s<>"{}|\\^`\[\]]+', re.IGNORECASE
         )
-        
+
         urls = url_pattern.findall(text)
-        return [url.rstrip('.,;:!?)]}') for url in urls]
-    
+        return [url.rstrip(".,;:!?)]}") for url in urls]
+
     def _extract_urls_from_html(self, html_text: str) -> List[str]:
         """Extract URLs from HTML content."""
         from bs4 import BeautifulSoup
-        
+
         try:
-            soup = BeautifulSoup(html_text, 'html.parser')
+            soup = BeautifulSoup(html_text, "html.parser")
             urls = []
-            
+
             # Extract from href attributes
-            for link in soup.find_all(['a', 'link'], href=True):
-                urls.append(link['href'])
-                
+            for link in soup.find_all(["a", "link"], href=True):
+                urls.append(link["href"])
+
             # Extract from src attributes
-            for element in soup.find_all(['img', 'script', 'iframe'], src=True):
-                urls.append(element['src'])
-                
-            return [url for url in urls if url.startswith(('http://', 'https://'))]
+            for element in soup.find_all(["img", "script", "iframe"], src=True):
+                urls.append(element["src"])
+
+            return [url for url in urls if url.startswith(("http://", "https://"))]
         except Exception as e:
             logger.warning(f"Error extracting URLs from HTML: {e}")
             return []
-        
-    def _parse_message_structure(self, root_msg: Message, output_dir: str) -> Dict[str, Any]:
+
+    def _parse_message_structure(
+        self, root_msg: Message, output_dir: str
+    ) -> Dict[str, Any]:
         """Parse the complete message structure with content deduplication and enhanced carrier detection."""
         result = {
             "parser_info": {
                 "version": "1.1",
                 "purpose": "phishing_email_analysis",
-                "features": ["content_deduplication", "enhanced_carrier_detection", "user_submission_detection"]
+                "features": [
+                    "content_deduplication",
+                    "enhanced_carrier_detection",
+                    "user_submission_detection",
+                ],
             },
             "message_layers": [],
             "carrier_analysis": {
                 "total_carriers": 0,
                 "security_appliances": [],
                 "user_submissions": [],
-                "analysis_recommendations": []
+                "analysis_recommendations": [],
             },
             "summary": {
                 "total_layers": 0,
@@ -496,270 +533,315 @@ class PhishingEmailParser:
                 "total_attachments": 0,
                 "total_images": 0,
                 "total_urls": 0,
-                "has_nested_emails": False
-            }
+                "has_nested_emails": False,
+            },
         }
-        
+
         # Initialize deduplicator
         deduplicator = EmailContentDeduplicator()
-        
+
         # Walk through all message layers using the existing MIME walker
         for depth, msg, vendor_tag in walk_layers(root_msg):
             # Check for duplicate content
             if deduplicator.is_duplicate_content(msg, depth):
                 logger.info(f"Skipping duplicate content at layer {depth}")
                 continue
-            
+
             # Mark as processed before parsing to prevent recursion issues
             deduplicator.mark_as_processed(msg, depth)
-            
+
             layer_data = self._parse_single_layer(msg, depth, vendor_tag, output_dir)
             result["message_layers"].append(layer_data)
-            
+
             # Log layer processing for debugging
             self._log_layer_processing(layer_data)
-            
+
             # Update carrier analysis
             self._update_carrier_analysis(layer_data, result["carrier_analysis"])
-            
+
             # Update summary
             result["summary"]["total_layers"] += 1
             if layer_data["is_carrier_email"]:
-                result["summary"]["carrier_emails"].append({
-                    "layer": depth,
-                    "vendor": layer_data["carrier_vendor"],
-                    "type": layer_data.get("carrier_details", {}).get("type", "unknown"),
-                    "priority": layer_data["analysis_priority"]
-                })
+                result["summary"]["carrier_emails"].append(
+                    {
+                        "layer": depth,
+                        "vendor": layer_data["carrier_vendor"],
+                        "type": layer_data.get("carrier_details", {}).get(
+                            "type", "unknown"
+                        ),
+                        "priority": layer_data["analysis_priority"],
+                    }
+                )
             if depth > 0:
                 result["summary"]["has_nested_emails"] = True
-        
+
         # Process attachment-based nested emails (with deduplication)
         nested_layers = self._process_nested_email_attachments_dedupe(
-            result["message_layers"], 
-            output_dir, 
-            deduplicator
+            result["message_layers"], output_dir, deduplicator
         )
-        
+
         # Update carrier analysis for nested layers
         for nested_layer in nested_layers:
             self._update_carrier_analysis(nested_layer, result["carrier_analysis"])
-        
+
         result["message_layers"].extend(nested_layers)
-        
+
         # Final summary update
         result["summary"]["total_layers"] = len(result["message_layers"])
         if nested_layers:
             result["summary"]["has_nested_emails"] = True
-        
+
         # Generate analysis recommendations
         self._generate_analysis_recommendations(result)
-        
+
         # Aggregate final counts
         self._update_summary_counts(result)
-        
+
         return result
 
-    def _update_carrier_analysis(self, layer_data: Dict[str, Any], carrier_analysis: Dict[str, Any]):
+    def _update_carrier_analysis(
+        self, layer_data: Dict[str, Any], carrier_analysis: Dict[str, Any]
+    ):
         """Update carrier analysis with information from a processed layer."""
         if not layer_data.get("is_carrier_email"):
             return
-        
+
         carrier_analysis["total_carriers"] += 1
-        
+
         carrier_details = layer_data.get("carrier_details")
         if carrier_details:
             carrier_type = carrier_details.get("type")
-            
+
             if carrier_type == "security_appliance":
-                carrier_analysis["security_appliances"].append({
-                    "layer": layer_data["layer_depth"],
-                    "vendor": layer_data["carrier_vendor"],
-                    "detection_method": carrier_details.get("detection_method", "unknown")
-                })
+                carrier_analysis["security_appliances"].append(
+                    {
+                        "layer": layer_data["layer_depth"],
+                        "vendor": layer_data["carrier_vendor"],
+                        "detection_method": carrier_details.get(
+                            "detection_method", "unknown"
+                        ),
+                    }
+                )
             elif carrier_type == "user_submission":
                 evidence = carrier_details.get("evidence", {})
-                carrier_analysis["user_submissions"].append({
-                    "layer": layer_data["layer_depth"],
-                    "submission_type": layer_data["carrier_vendor"],
-                    "confidence_score": evidence.get("confidence_score", 0),
-                    "evidence_count": len(evidence.get("structural_indicators", [])),
-                    "summary": layer_data["carrier_summary"]
-                })
+                carrier_analysis["user_submissions"].append(
+                    {
+                        "layer": layer_data["layer_depth"],
+                        "submission_type": layer_data["carrier_vendor"],
+                        "confidence_score": evidence.get("confidence_score", 0),
+                        "evidence_count": len(
+                            evidence.get("structural_indicators", [])
+                        ),
+                        "summary": layer_data["carrier_summary"],
+                    }
+                )
 
     def _generate_analysis_recommendations(self, result: Dict[str, Any]):
         """Generate LLM analysis recommendations based on carrier detection."""
         recommendations = []
         high_priority_layers = []
-        
+
         for layer in result["message_layers"]:
             if layer.get("analysis_priority") == "HIGH":
                 high_priority_layers.append(layer["layer_depth"])
-        
+
         if high_priority_layers:
-            recommendations.append({
-                "priority": "HIGH",
-                "action": "focus_analysis",
-                "layers": high_priority_layers,
-                "reason": "These layers contain non-carrier content and should be the primary focus of threat analysis"
-            })
-        
+            recommendations.append(
+                {
+                    "priority": "HIGH",
+                    "action": "focus_analysis",
+                    "layers": high_priority_layers,
+                    "reason": "These layers contain non-carrier content and should be the primary focus of threat analysis",
+                }
+            )
+
         if result["carrier_analysis"]["user_submissions"]:
-            recommendations.append({
-                "priority": "MEDIUM", 
-                "action": "validate_submission_context",
-                "reason": "User-submitted carriers detected - validate internal submission workflow and sender legitimacy"
-            })
-        
+            recommendations.append(
+                {
+                    "priority": "MEDIUM",
+                    "action": "validate_submission_context",
+                    "reason": "User-submitted carriers detected - validate internal submission workflow and sender legitimacy",
+                }
+            )
+
         if result["carrier_analysis"]["security_appliances"]:
-            recommendations.append({
-                "priority": "LOW",
-                "action": "review_security_processing",
-                "reason": "Security appliance processing detected - review why email reached analysis (bypass detection?)"
-            })
-        
+            recommendations.append(
+                {
+                    "priority": "LOW",
+                    "action": "review_security_processing",
+                    "reason": "Security appliance processing detected - review why email reached analysis (bypass detection?)",
+                }
+            )
+
         if result["summary"]["total_layers"] > 3:
-            recommendations.append({
-                "priority": "MEDIUM",
-                "action": "analyze_nesting_complexity",
-                "reason": f"Complex nesting detected ({result['summary']['total_layers']} layers) - may indicate advanced evasion techniques"
-            })
-        
+            recommendations.append(
+                {
+                    "priority": "MEDIUM",
+                    "action": "analyze_nesting_complexity",
+                    "reason": f"Complex nesting detected ({result['summary']['total_layers']} layers) - may indicate advanced evasion techniques",
+                }
+            )
+
         result["carrier_analysis"]["analysis_recommendations"] = recommendations
 
-    def _process_nested_email_attachments_dedupe(self, existing_layers: List[Dict], 
-                                               output_dir: str, 
-                                               deduplicator: EmailContentDeduplicator) -> List[Dict]:
+    def _process_nested_email_attachments_dedupe(
+        self,
+        existing_layers: List[Dict],
+        output_dir: str,
+        deduplicator: EmailContentDeduplicator,
+    ) -> List[Dict]:
         """Process nested email attachments with content deduplication."""
         nested_layers = []
-        
+
         for layer in existing_layers:
             current_depth = layer.get("layer_depth", 0)
             attachments = layer.get("attachments", [])
-            
+
             for attachment in attachments:
                 # Only process attachment-based nested emails
                 # BUT exclude message/rfc822 since those are handled by walk_layers
-                if (attachment.get("is_nested_email", False) and 
-                    attachment.get("content_type") != "message/rfc822"):
-                    
-                    logger.info(f"Processing attachment-based nested email: {attachment['filename']}")
-                    
+                if (
+                    attachment.get("is_nested_email", False)
+                    and attachment.get("content_type") != "message/rfc822"
+                ):
+
+                    logger.info(
+                        f"Processing attachment-based nested email: {attachment['filename']}"
+                    )
+
                     try:
-                        nested_email_layers = self._parse_nested_email_attachment_dedupe(
-                            attachment, current_depth + 1, output_dir, deduplicator
+                        nested_email_layers = (
+                            self._parse_nested_email_attachment_dedupe(
+                                attachment, current_depth + 1, output_dir, deduplicator
+                            )
                         )
                         nested_layers.extend(nested_email_layers)
-                        
+
                     except Exception as e:
-                        logger.error(f"Error parsing nested email {attachment['filename']}: {e}")
+                        logger.error(
+                            f"Error parsing nested email {attachment['filename']}: {e}"
+                        )
                         attachment["nested_parse_error"] = str(e)
-        
+
         return nested_layers
 
-    def _parse_nested_email_attachment_dedupe(self, attachment: Dict, base_depth: int, 
-                                            output_dir: str, 
-                                            deduplicator: EmailContentDeduplicator) -> List[Dict]:
+    def _parse_nested_email_attachment_dedupe(
+        self,
+        attachment: Dict,
+        base_depth: int,
+        output_dir: str,
+        deduplicator: EmailContentDeduplicator,
+    ) -> List[Dict]:
         """Parse a nested email attachment with deduplication."""
         disk_path = attachment.get("disk_path")
         if not disk_path or not os.path.exists(disk_path):
             logger.warning(f"Nested email file not found: {disk_path}")
             return []
-        
+
         try:
             # Load and parse the nested email file
-            with open(disk_path, 'rb') as f:
+            with open(disk_path, "rb") as f:
                 nested_msg = BytesParser(policy=policy.default).parse(f)
-            
+
             # Check if this content is a duplicate
             if deduplicator.is_duplicate_content(nested_msg, base_depth):
-                logger.info(f"Skipping duplicate nested email: {attachment['filename']}")
+                logger.info(
+                    f"Skipping duplicate nested email: {attachment['filename']}"
+                )
                 return []
-            
-            logger.debug(f"Processing unique nested email from {attachment['filename']} at depth {base_depth}")
-            
+
+            logger.debug(
+                f"Processing unique nested email from {attachment['filename']} at depth {base_depth}"
+            )
+
             nested_layers = []
-            
+
             # Walk through the nested email
             for depth, msg, vendor_tag in walk_layers(nested_msg):
                 adjusted_depth = base_depth + depth
-                
+
                 # Check for duplicates at adjusted depth
                 if deduplicator.is_duplicate_content(msg, adjusted_depth):
                     logger.debug(f"Skipping duplicate layer at depth {adjusted_depth}")
                     continue
-                
+
                 # Mark as processed
                 deduplicator.mark_as_processed(msg, adjusted_depth)
-                
-                layer_data = self._parse_single_layer(msg, adjusted_depth, vendor_tag, output_dir)
-                
+
+                layer_data = self._parse_single_layer(
+                    msg, adjusted_depth, vendor_tag, output_dir
+                )
+
                 # Add metadata showing this came from a nested attachment
                 layer_data["parent_attachment"] = {
                     "filename": attachment["filename"],
                     "parent_layer_depth": base_depth - 1,
-                    "attachment_index": attachment.get("index")
+                    "attachment_index": attachment.get("index"),
                 }
-                
+
                 # Log layer processing
                 self._log_layer_processing(layer_data)
-                
+
                 nested_layers.append(layer_data)
                 logger.debug(f"Added unique nested layer at depth {adjusted_depth}")
-            
+
             # Recursively process any further nested emails
             if nested_layers:
                 deeper_nested = self._process_nested_email_attachments_dedupe(
                     nested_layers, output_dir, deduplicator
                 )
                 nested_layers.extend(deeper_nested)
-            
+
             return nested_layers
-            
+
         except Exception as e:
             logger.error(f"Error parsing nested email file {disk_path}: {e}")
             raise
 
     def _update_summary_counts(self, result: Dict[str, Any]):
-            """Update summary counts after deduplication."""
-            all_urls = []
-            total_attachments = 0
-            total_images = 0
-            total_embedded_images = 0
-            
-            for layer in result["message_layers"]:
-                if "urls" in layer:
-                    all_urls.extend(layer["urls"])
-                if "attachments" in layer:
-                    total_attachments += len(layer["attachments"])
-                    # Count embedded images from Excel files
-                    for attachment in layer["attachments"]:
-                        if "embedded_images" in attachment:
-                            total_embedded_images += len(attachment["embedded_images"])
-                if "images" in layer:
-                    total_images += len(layer["images"])
-            
-            result["summary"]["total_urls"] = len(all_urls)
-            result["summary"]["total_attachments"] = total_attachments
-            result["summary"]["total_images"] = total_images
-            result["summary"]["total_embedded_images"] = total_embedded_images
-            
-            # Log embedded image extraction results
-            if total_embedded_images > 0:
-                logger.info(f"Found {total_embedded_images} embedded images in Excel attachments")
+        """Update summary counts after deduplication."""
+        all_urls = []
+        total_attachments = 0
+        total_images = 0
+        total_embedded_images = 0
+
+        for layer in result["message_layers"]:
+            if "urls" in layer:
+                all_urls.extend(layer["urls"])
+            if "attachments" in layer:
+                total_attachments += len(layer["attachments"])
+                # Count embedded images from Excel files
+                for attachment in layer["attachments"]:
+                    if "embedded_images" in attachment:
+                        total_embedded_images += len(attachment["embedded_images"])
+            if "images" in layer:
+                total_images += len(layer["images"])
+
+        result["summary"]["total_urls"] = len(all_urls)
+        result["summary"]["total_attachments"] = total_attachments
+        result["summary"]["total_images"] = total_images
+        result["summary"]["total_embedded_images"] = total_embedded_images
+
+        # Log embedded image extraction results
+        if total_embedded_images > 0:
+            logger.info(
+                f"Found {total_embedded_images} embedded images in Excel attachments"
+            )
 
     def _log_layer_processing(self, layer_data: Dict[str, Any]):
         """Log layer processing details for debugging."""
         depth = layer_data.get("layer_depth", 0)
         subject = layer_data.get("headers", {}).get("subject", "No Subject")[:50]
         from_addr = layer_data.get("headers", {}).get("from", "No From")[:30]
-        
+
         carrier_info = ""
         if layer_data.get("is_carrier_email"):
-            carrier_info = f" [{layer_data['carrier_vendor']} - {layer_data['analysis_priority']}]"
-        
+            carrier_info = (
+                f" [{layer_data['carrier_vendor']} - {layer_data['analysis_priority']}]"
+            )
+
         logger.info(f"Layer {depth}: '{subject}' from '{from_addr}'{carrier_info}")
-        
+
         if layer_data.get("parent_attachment"):
             parent_info = layer_data["parent_attachment"]
             logger.info(f"  ↳ From attachment: {parent_info['filename']}")
@@ -767,41 +849,42 @@ class PhishingEmailParser:
     def analyze_email_structure(self, email_path: str) -> Dict[str, Any]:
         """
         Perform detailed analysis of email structure for debugging and understanding.
-        
+
         Args:
             email_path: Path to email file
-            
+
         Returns:
             Detailed analysis including carrier detection debugging
         """
         email_path = Path(email_path)
-        
+
         if not email_path.exists():
             raise FileNotFoundError(f"Email file not found: {email_path}")
-            
+
         # Convert .msg to .eml if needed
-        if email_path.suffix.lower() == '.msg':
+        if email_path.suffix.lower() == ".msg":
             eml_path = self.msg_converter.convert_msg_to_eml(
-                str(email_path), 
-                self.temp_dir
+                str(email_path), self.temp_dir
             )
             email_path = Path(eml_path)
-        
+
         # Parse the email
-        with open(email_path, 'rb') as f:
+        with open(email_path, "rb") as f:
             msg = BytesParser(policy=policy.default).parse(f)
-        
+
         # Perform detailed analysis
         analysis = {
             "file_info": {
                 "path": str(email_path),
                 "size": email_path.stat().st_size,
-                "type": email_path.suffix
+                "type": email_path.suffix,
             },
             "structure_analysis": analyze_potential_carrier(msg),
-            "parsing_preview": self._parse_message_structure(msg, str(email_path.parent))
+            "parsing_preview": self._parse_message_structure(
+                msg, str(email_path.parent)
+            ),
         }
-        
+
         return analysis
 
 
@@ -813,17 +896,19 @@ def main():
         print("  output_file: Optional JSON output file (default: stdout)")
         print("  --analyze: Perform detailed structure analysis (debugging)")
         sys.exit(1)
-    
+
     email_file = sys.argv[1]
-    output_file = sys.argv[2] if len(sys.argv) >= 3 and not sys.argv[2].startswith('--') else None
-    analyze_mode = '--analyze' in sys.argv
-    
+    output_file = (
+        sys.argv[2] if len(sys.argv) >= 3 and not sys.argv[2].startswith("--") else None
+    )
+    analyze_mode = "--analyze" in sys.argv
+
     # Configure logging
     logging.basicConfig(
         level=logging.DEBUG,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
-    
+
     try:
         with PhishingEmailParser() as parser:
             if analyze_mode:
@@ -832,14 +917,14 @@ def main():
                 print("=" * 50)
             else:
                 result = parser.parse_email_file(email_file)
-            
+
             if output_file:
-                with open(output_file, 'w', encoding='utf-8') as f:
+                with open(output_file, "w", encoding="utf-8") as f:
                     json.dump(result, f, indent=2, ensure_ascii=False)
                 print(f"Results written to {output_file}")
             else:
                 print(json.dumps(result, indent=2, ensure_ascii=False))
-                
+
     except Exception as e:
         logger.error(f"Error parsing email: {e}")
         sys.exit(1)

--- a/phishing_email_parser/processing/attachment_processor.py
+++ b/phishing_email_parser/processing/attachment_processor.py
@@ -15,6 +15,9 @@ from email.message import Message
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..config import DEFAULT_CONFIG, ParserConfig
+from ..exceptions import AttachmentProcessingError
+
 from .pdf_utils import extract_text_from_pdf
 from .excel_utils import extract_text_from_excel, extract_excel_with_images
 
@@ -23,37 +26,27 @@ logger = logging.getLogger(__name__)
 
 class AttachmentProcessor:
     """Process email attachments for phishing analysis."""
-    
-    # File types that commonly contain text content
-    TEXT_EXTRACTABLE_TYPES = {
-        'application/pdf',
-        'text/plain',
-        'text/html',
-        'text/csv',
-        'application/rtf',
-        'application/msword',
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        'application/vnd.ms-excel',
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-    }
-    
-    # Suspicious file extensions to flag
-    SUSPICIOUS_EXTENSIONS = {
-        '.exe', '.scr', '.bat', '.cmd', '.com', '.pif', '.vbs', '.js', '.jar',
-        '.zip', '.rar', '.7z', '.ace', '.arj', '.cab', '.lzh', '.tar', '.gz'
-    }
-    
-    def __init__(self, temp_dir: str):
-        """Initialize with temporary directory for file extraction."""
+
+    def __init__(self, temp_dir: str, config: ParserConfig | None = None) -> None:
+        """Initialize the processor.
+
+        Args:
+            temp_dir: Directory used for temporary extracted files.
+            config: Optional parser configuration. If ``None`` ``DEFAULT_CONFIG`` is used.
+        """
+
         self.temp_dir = temp_dir
+        self.config = config or DEFAULT_CONFIG
         os.makedirs(temp_dir, exist_ok=True)
-        
-    def process_attachments(self, msg: Message, output_dir: str) -> List[Dict[str, Any]]:
+
+    def process_attachments(
+        self, msg: Message, output_dir: str
+    ) -> List[Dict[str, Any]]:
         """Process all attachments in an email message."""
         logger.debug("Processing attachments to %s", output_dir)
         attachments = []
         attachment_idx = 1
-        
+
         for part in msg.iter_attachments():
             try:
                 content_type = part.get_content_type()
@@ -65,7 +58,9 @@ class AttachmentProcessor:
 
                 if content_type.startswith("message/"):
                     nested_obj = (
-                        part.get_payload(0) if part.is_multipart() else part.get_payload()
+                        part.get_payload(0)
+                        if part.is_multipart()
+                        else part.get_payload()
                     )
                     if isinstance(nested_obj, email.message.Message):
                         raw_bytes = nested_obj.as_bytes(policy=policy.default)
@@ -96,57 +91,60 @@ class AttachmentProcessor:
                 if attachment_data:
                     attachments.append(attachment_data)
                     attachment_idx += 1
-            except Exception as e:
-                logger.error(f"Error processing attachment {attachment_idx}: {e}")
-                # Create minimal error entry
-                attachments.append({
-                    "index": attachment_idx,
-                    "filename": f"attachment_{attachment_idx}_error",
-                    "error": str(e),
-                    "processed": False
-                })
+            except Exception as e:  # pragma: no cover - unexpected errors
+                logger.error("Error processing attachment %s: %s", attachment_idx, e)
+                attachments.append(
+                    {
+                        "index": attachment_idx,
+                        "filename": f"attachment_{attachment_idx}_error",
+                        "error": str(e),
+                        "processed": False,
+                    }
+                )
                 attachment_idx += 1
+                raise AttachmentProcessingError(str(e)) from e
 
         logger.debug("Finished processing attachments: %d found", len(attachments))
         return attachments
-    
-    def _process_single_attachment(self, part: Message, index: int,
-                                 output_dir: str) -> Optional[Dict[str, Any]]:
+
+    def _process_single_attachment(
+        self, part: Message, index: int, output_dir: str
+    ) -> Optional[Dict[str, Any]]:
         """Process a single email attachment."""
         filename = part.get_filename()
         if not filename:
             filename = f"attachment_{index}"
         else:
             # Strip null terminators and other problematic characters
-            filename = filename.rstrip('\x00').strip()
+            filename = filename.rstrip("\x00").strip()
 
         # FIXED: Clean content type to remove null bytes
         content_type = part.get_content_type()
         if content_type:
-            content_type = content_type.rstrip('\x00').strip()
+            content_type = content_type.rstrip("\x00").strip()
 
         logger.debug("Processing attachment %d: %s (%s)", index, filename, content_type)
-            
+
         payload = part.get_payload(decode=True)
-        
+
         if not payload:
             return None
-            
+
         # Save attachment to disk
         file_path = os.path.join(output_dir, filename)
         try:
-            with open(file_path, 'wb') as f:
+            with open(file_path, "wb") as f:
                 f.write(payload)
             logger.debug("Attachment %s written to %s", filename, file_path)
         except Exception as e:
             logger.error(f"Error saving attachment {filename}: {e}")
             file_path = None
-        
+
         # Basic file analysis
         file_size = len(payload)
         file_hash = hashlib.sha256(payload).hexdigest()
         file_extension = Path(filename).suffix.lower()
-        
+
         attachment_info = {
             "index": index,
             "filename": filename,
@@ -155,64 +153,77 @@ class AttachmentProcessor:
             "sha256": file_hash,
             "extension": file_extension,
             "disk_path": file_path,
-            "is_suspicious_extension": file_extension in self.SUSPICIOUS_EXTENSIONS,
+            "is_suspicious_extension": file_extension
+            in self.config.suspicious_extensions,
             "text_content": None,
             "urls": [],
             "processed": True,
-            "embedded_images": []  # NEW: Track images extracted from this attachment
+            "embedded_images": [],  # NEW: Track images extracted from this attachment
         }
-        
+
         # Extract text content and images if possible
-        if content_type in self.TEXT_EXTRACTABLE_TYPES:
+        if content_type in self.config.text_extractable_types:
             # ENHANCED: Use new Excel processing for Excel files
-            if content_type in [
-                'application/vnd.ms-excel',
-                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-            ]:
+            if content_type in (
+                "application/vnd.ms-excel",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ):
                 text_content, extracted_images = self._extract_from_excel_with_images(
                     payload, filename, output_dir
                 )
                 attachment_info["text_content"] = text_content
                 attachment_info["embedded_images"] = extracted_images
-                
+
                 # Collect URLs from text content and extracted images
                 if text_content:
-                    attachment_info["urls"].extend(self._extract_urls_from_text(text_content))
-                
+                    attachment_info["urls"].extend(
+                        self._extract_urls_from_text(text_content)
+                    )
+
                 # Add URLs from embedded images
                 for img in extracted_images:
                     if img.get("urls_from_ocr"):
                         attachment_info["urls"].extend(img["urls_from_ocr"])
                     if img.get("hyperlinks"):
                         attachment_info["urls"].extend(img["hyperlinks"])
-                
+
                 # Log image extraction results
                 if extracted_images:
-                    logger.info(f"Extracted {len(extracted_images)} images from Excel file {filename}")
-                    
+                    logger.info(
+                        f"Extracted {len(extracted_images)} images from Excel file {filename}"
+                    )
+
             else:
                 # Use standard text extraction for other file types
-                text_content = self._extract_text_from_attachment(payload, content_type, filename)
+                text_content = self._extract_text_from_attachment(
+                    payload, content_type, filename
+                )
                 if text_content:
                     attachment_info["text_content"] = text_content
                     # Extract URLs from text content
                     urls = self._extract_urls_from_text(text_content)
                     attachment_info["urls"] = urls
-        
+
         # Remove duplicate URLs
         attachment_info["urls"] = list(set(attachment_info["urls"]))
-        
+
         # ENHANCED: Detect nested emails using multiple criteria
         # BUT exclude message/rfc822 since those are handled by walk_layers
         is_nested_email = (
-            (filename.lower().endswith('.eml') or self._is_email_content_heuristic(payload)) and
-            content_type != "message/rfc822"  # FIXED: Exclude MIME parts handled by walk_layers
+            (
+                filename.lower().endswith(".eml")
+                or self._is_email_content_heuristic(payload)
+            )
+            and content_type
+            != "message/rfc822"  # FIXED: Exclude MIME parts handled by walk_layers
         )
-        
+
         attachment_info["is_nested_email"] = is_nested_email
-        
+
         if is_nested_email:
-            logger.info(f"Detected attachment-based nested email: {filename} (content_type: {content_type})")
+            logger.info(
+                f"Detected attachment-based nested email: {filename} (content_type: {content_type})"
+            )
 
         logger.debug(
             "Attachment %s processed: size=%d, nested_email=%s, content_type=%s, images=%d",
@@ -220,28 +231,33 @@ class AttachmentProcessor:
             file_size,
             is_nested_email,
             content_type,
-            len(attachment_info["embedded_images"])
+            len(attachment_info["embedded_images"]),
         )
 
         return attachment_info
-    
-    def _extract_from_excel_with_images(self, payload: bytes, filename: str, 
-                                      output_dir: str) -> tuple[Optional[str], List[Dict]]:
+
+    def _extract_from_excel_with_images(
+        self, payload: bytes, filename: str, output_dir: str
+    ) -> tuple[Optional[str], List[Dict]]:
         """Extract text and images from Excel files."""
         try:
             logger.debug(f"Extracting text and images from Excel file: {filename}")
-            
+
             # Create subdirectory for this Excel file's images
             excel_image_dir = os.path.join(output_dir, f"{Path(filename).stem}_images")
             os.makedirs(excel_image_dir, exist_ok=True)
-            
+
             # Use enhanced extraction
-            text_content, extracted_images = extract_excel_with_images(payload, excel_image_dir)
-            
-            logger.debug(f"Excel extraction results: {len(text_content) if text_content else 0} chars text, {len(extracted_images)} images")
-            
+            text_content, extracted_images = extract_excel_with_images(
+                payload, excel_image_dir
+            )
+
+            logger.debug(
+                f"Excel extraction results: {len(text_content) if text_content else 0} chars text, {len(extracted_images)} images"
+            )
+
             return text_content, extracted_images
-            
+
         except Exception as e:
             logger.warning(f"Error extracting from Excel file {filename}: {e}")
             # Fallback to basic text extraction
@@ -249,39 +265,43 @@ class AttachmentProcessor:
                 text_content = extract_text_from_excel(payload)
                 return text_content, []
             except Exception as fallback_e:
-                logger.error(f"Fallback Excel extraction also failed for {filename}: {fallback_e}")
+                logger.error(
+                    f"Fallback Excel extraction also failed for {filename}: {fallback_e}"
+                )
                 return f"[Error extracting Excel content: {e}]", []
-    
-    def _extract_text_from_attachment(self, payload: bytes, content_type: str, 
-                                    filename: str) -> Optional[str]:
+
+    def _extract_text_from_attachment(
+        self, payload: bytes, content_type: str, filename: str
+    ) -> Optional[str]:
         """Extract text content from attachment based on content type."""
         try:
-            if content_type == 'application/pdf':
+            if content_type == "application/pdf":
                 return extract_text_from_pdf(payload)
-            elif content_type.startswith('text/'):
+            elif content_type.startswith("text/"):
                 # Try to decode as text
-                for encoding in ['utf-8', 'utf-16', 'iso-8859-1', 'cp1252']:
+                for encoding in ["utf-8", "utf-16", "iso-8859-1", "cp1252"]:
                     try:
                         return payload.decode(encoding)
                     except UnicodeDecodeError:
                         continue
-                return payload.decode('utf-8', errors='replace')
-            elif content_type == 'text/html':
+                return payload.decode("utf-8", errors="replace")
+            elif content_type == "text/html":
                 # Import here to avoid circular import
                 from ..core.html_cleaner import PhishingEmailHtmlCleaner
-                html_text = payload.decode('utf-8', errors='replace')
+
+                html_text = payload.decode("utf-8", errors="replace")
                 return PhishingEmailHtmlCleaner.clean_html(html_text)
             elif content_type in [
-                'application/vnd.ms-excel',
-                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+                "application/vnd.ms-excel",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             ]:
                 # This case is now handled by _extract_from_excel_with_images
                 # But keep for backwards compatibility
                 logger.debug(f"Using basic Excel extraction for: {filename}")
                 return extract_text_from_excel(payload)
             elif content_type in [
-                'application/msword',
-                'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+                "application/msword",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             ]:
                 return self._extract_from_office_doc(payload, filename)
             else:
@@ -289,7 +309,9 @@ class AttachmentProcessor:
                 try:
                     # Check if it looks like text first
                     if self._is_likely_text_content(payload):
-                        return payload.decode('utf-8', errors='replace')[:1000]  # Limit size
+                        return payload.decode("utf-8", errors="replace")[
+                            :1000
+                        ]  # Limit size
                     else:
                         return f"[Binary file: {content_type}]"
                 except Exception:
@@ -297,70 +319,71 @@ class AttachmentProcessor:
         except Exception as e:
             logger.warning(f"Error extracting text from {filename}: {e}")
             return f"[Error extracting text: {e}]"
-    
+
     def _is_likely_text_content(self, payload: bytes) -> bool:
         """Check if binary payload is likely to contain text."""
         if not payload:
             return False
-        
+
         # Sample first 1000 bytes
         sample = payload[:1000]
-        
+
         # Count printable ASCII characters
         printable_count = sum(1 for b in sample if 32 <= b <= 126 or b in [9, 10, 13])
         ratio = printable_count / len(sample)
-        
+
         # If more than 70% printable ASCII, likely text
         return ratio > 0.7
-    
+
     def _extract_from_office_doc(self, payload: bytes, filename: str) -> Optional[str]:
         """Extract text from Office documents."""
         try:
             # Try to use python-docx for Word documents
-            if filename.lower().endswith('.docx'):
+            if filename.lower().endswith(".docx"):
                 try:
                     from io import BytesIO
 
                     import docx
+
                     doc = docx.Document(BytesIO(payload))
-                    return '\n'.join([paragraph.text for paragraph in doc.paragraphs])
+                    return "\n".join([paragraph.text for paragraph in doc.paragraphs])
                 except ImportError:
                     logger.warning("python-docx not available for .docx extraction")
                 except Exception as e:
                     logger.warning(f"Error with docx extraction: {e}")
-            
+
             # For other Office formats or fallback, try basic text extraction
-            text = payload.decode('utf-8', errors='replace')
+            text = payload.decode("utf-8", errors="replace")
             # Filter out binary noise, keep only printable text
             import string
+
             printable = set(string.printable)
-            filtered_text = ''.join(filter(lambda x: x in printable, text))
+            filtered_text = "".join(filter(lambda x: x in printable, text))
             if len(filtered_text) > 50:  # Only return if we got substantial text
                 return filtered_text[:2000]  # Limit size
             return None
         except Exception as e:
             logger.warning(f"Error extracting from Office document {filename}: {e}")
             return None
-    
+
     def _extract_urls_from_text(self, text: str) -> List[str]:
         """Extract URLs from text content."""
         if not text:
             return []
-            
+
         # Pattern to match URLs
         url_pattern = re.compile(
-            r'https?://[^\s<>"{}|\\^`\[\]]+|www\.[^\s<>"{}|\\^`\[\]]+',
-            re.IGNORECASE
+            r'https?://[^\s<>"{}|\\^`\[\]]+|www\.[^\s<>"{}|\\^`\[\]]+', re.IGNORECASE
         )
-        
+
         urls = url_pattern.findall(text)
         # Clean up URLs (remove trailing punctuation)
         cleaned_urls = []
         for url in urls:
-            cleaned = url.rstrip('.,;:!?)]}')
+            cleaned = url.rstrip(".,;:!?)]}")
             if cleaned:
                 cleaned_urls.append(cleaned)
-        
+
         return list(set(cleaned_urls))  # Remove duplicates
 
     def _is_email_content_heuristic(self, data: bytes) -> bool:
@@ -368,32 +391,53 @@ class AttachmentProcessor:
         try:
             # Try to decode as text and look for email headers
             if isinstance(data, bytes):
-                text_data = data.decode('utf-8', errors='replace')[:2000]  # Check first 2000 chars
+                text_data = data.decode("utf-8", errors="replace")[
+                    :2000
+                ]  # Check first 2000 chars
             else:
                 text_data = str(data)[:2000]
-            
+
             # Look for common email headers (more comprehensive list)
             email_indicators = [
-                'Received:', 'From:', 'To:', 'Subject:', 'Date:', 'Message-ID:', 
-                'Return-Path:', 'X-Mailer:', 'MIME-Version:', 'Content-Type:',
-                'Delivered-To:', 'X-Originating-IP:', 'Authentication-Results:',
-                'DKIM-Signature:', 'Authentication-Results:'
+                "Received:",
+                "From:",
+                "To:",
+                "Subject:",
+                "Date:",
+                "Message-ID:",
+                "Return-Path:",
+                "X-Mailer:",
+                "MIME-Version:",
+                "Content-Type:",
+                "Delivered-To:",
+                "X-Originating-IP:",
+                "Authentication-Results:",
+                "DKIM-Signature:",
+                "Authentication-Results:",
             ]
-            
-            found_headers = sum(1 for indicator in email_indicators if indicator in text_data)
-            
+
+            found_headers = sum(
+                1 for indicator in email_indicators if indicator in text_data
+            )
+
             # Also check for typical email structure patterns
-            has_header_block = bool(re.search(r'^[A-Za-z-]+:\s+.+$', text_data, re.MULTILINE))
-            has_mime_boundary = 'boundary=' in text_data
-            
+            has_header_block = bool(
+                re.search(r"^[A-Za-z-]+:\s+.+$", text_data, re.MULTILINE)
+            )
+            has_mime_boundary = "boundary=" in text_data
+
             # If we find multiple email headers or typical email structure, it's likely an email
-            is_email = (found_headers >= 3) or (found_headers >= 2 and (has_header_block or has_mime_boundary))
-            
+            is_email = (found_headers >= 3) or (
+                found_headers >= 2 and (has_header_block or has_mime_boundary)
+            )
+
             if is_email:
-                logger.debug(f"Content analysis detected email: {found_headers} headers found")
-            
+                logger.debug(
+                    f"Content analysis detected email: {found_headers} headers found"
+                )
+
             return is_email
-            
+
         except Exception as e:
             logger.debug(f"Error in email content heuristic: {e}")
             return False


### PR DESCRIPTION
## Summary
- add a dataclass-based configuration module
- expose `ParserConfig` in the public API
- refactor `AttachmentProcessor` to use config and raise custom error
- extend `PhishingEmailParser` for dependency injection and validation
- document custom configuration usage

## Testing
- `make fmt` *(fails: No rule to make target)*
- `make test` *(fails: No rule to make target)*
- `make lint` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_68697513ca788324a09b8f76b8130c34